### PR TITLE
fixed config generation

### DIFF
--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -54,23 +54,19 @@ namespace WindowsGSM.Plugins
         // - Create a default cfg for the game server after installation
         public async void CreateServerCFG()
         {
-            // Nothing
-        }
-
-        // - Start server function, return its Process to WindowsGSM
-        public async Task<Process> Start()
-        {
             string configPath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, @"server properties.txt");
-            {
             string configText = File.ReadAllText(configPath);
             configText = configText.Replace("Default Session", serverData.ServerName);
             configText = configText.Replace("27015", serverData.ServerPort);
             configText = configText.Replace("27016", serverData.ServerQueryPort);
             configText = configText.Replace("authentication token = ", "authentication token = "+serverData.ServerGSLT);
-            configText = configText.Replace(serverData.ServerGSLT+serverData.ServerGSLT, serverData.ServerGSLT);
+            //configText = configText.Replace(serverData.ServerGSLT+serverData.ServerGSLT, serverData.ServerGSLT);
             File.WriteAllText(configPath, configText);
-            }
+        }
 
+        // - Start server function, return its Process to WindowsGSM
+        public async Task<Process> Start()
+        {
             string shipExePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, StartPath);
             if (!File.Exists(shipExePath))
             {
@@ -103,7 +99,7 @@ namespace WindowsGSM.Plugins
             p.StartInfo.EnvironmentVariables["SteamAppId"] = "1898300";
 
             // Set up Redirect Input and Output to WindowsGSM Console if EmbedConsole is on
-            if (AllowsEmbedConsole)
+            if (serverData.EmbedConsole)
             {
                 p.StartInfo.RedirectStandardInput = true;
                 p.StartInfo.RedirectStandardOutput = true;
@@ -119,7 +115,7 @@ namespace WindowsGSM.Plugins
             try
             {
                 p.Start();
-                if (AllowsEmbedConsole)
+                if (serverData.EmbedConsole)
                 {
                     p.BeginOutputReadLine();
                     p.BeginErrorReadLine();

--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -101,7 +101,12 @@ namespace WindowsGSM.Plugins
                 return null;
             }
 
+            if (string.IsNullOrWhiteSpace(serverData.ServerGSLT))
+            {
+                Error = "No Steam GSLT token found. Please set it by Clicking Edit Config in Windowsgsm";
+            }
             CreateServerCFG(); // add // at the start of this line if you don't want wgsm to update your config file 
+
 
             // Prepare start parameter
             string param = "-propertiesPath \"server properties.txt\"";

--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -64,27 +64,27 @@ namespace WindowsGSM.Plugins
             {
                 if (line.StartsWith("steam game port ="))
                 {
-                    sb.Append($"steam game port = {serverData.ServerPort}");
+                    sb.AppendLine($"steam game port = {serverData.ServerPort}");
                 }
                 else if (line.StartsWith("steam query port ="))
                 {
-                    sb.Append($"steam query port = {serverData.ServerQueryPort}");
+                    sb.AppendLine($"steam query port = {serverData.ServerQueryPort}");
                 }
                 else if (line.StartsWith("server name = "))
                 {
-                    sb.Append($"server name = {serverData.ServerName}");
+                    sb.AppendLine($"server name = {serverData.ServerName}");
                 }
                 else if (line.StartsWith("display name ="))
                 {
-                    sb.Append($"display name = {serverData.ServerName}");
+                    sb.AppendLine($"display name = {serverData.ServerName}");
                 }
-                //else if (line.StartsWith("authentication token ="))
-                //{
-                //    sb.Append($"authentication token = {serverData.ServerGSLT}"); 
-                //} //
+                else if (line.StartsWith("authentication token =")) 
+                {
+                    sb.Append($"authentication token = {serverData.ServerGSLT}"); 
+                }
                 else
                 {
-                    sb.Append(line);
+                    sb.AppendLine(line);
                 }
             }
 
@@ -101,13 +101,10 @@ namespace WindowsGSM.Plugins
                 return null;
             }
 
+            CreateServerCFG(); // add // at the start of this line if you don't want wgsm to update your config file 
+
             // Prepare start parameter
             string param = "-propertiesPath \"server properties.txt\"";
-            //param += $" {serverData.ServerParam}";
-            //param += string.IsNullOrWhiteSpace(serverData.ServerPort) ? string.Empty : $" -Port={serverData.ServerPort}"; 
-            //param += string.IsNullOrWhiteSpace(serverData.ServerQueryPort) ? string.Empty : $" -ServerQueryPort={serverData.ServerQueryPort}";
-            //param += string.IsNullOrWhiteSpace(serverData.ServerMaxPlayer) ? string.Empty : $" -MaxPlayers={serverData.ServerMaxPlayer}";
-            //param += string.IsNullOrWhiteSpace(serverData.ServerIP) ? string.Empty : $" -Multihome={serverData.ServerIP}";
 
             // Prepare Process
             var p = new Process

--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -5,6 +5,8 @@ using WindowsGSM.Functions;
 using WindowsGSM.GameServer.Query;
 using WindowsGSM.GameServer.Engine;
 using System.IO;
+using System.Linq;
+using System.Text;
 
 namespace WindowsGSM.Plugins
 {
@@ -55,13 +57,38 @@ namespace WindowsGSM.Plugins
         public async void CreateServerCFG()
         {
             string configPath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, @"server properties.txt");
-            string configText = File.ReadAllText(configPath);
-            configText = configText.Replace("Default Session", serverData.ServerName);
-            configText = configText.Replace("27015", serverData.ServerPort);
-            configText = configText.Replace("27016", serverData.ServerQueryPort);
-            configText = configText.Replace("authentication token = ", "authentication token = "+serverData.ServerGSLT);
-            //configText = configText.Replace(serverData.ServerGSLT+serverData.ServerGSLT, serverData.ServerGSLT);
-            File.WriteAllText(configPath, configText);
+
+            var content = File.ReadAllLines(configPath);
+            StringBuilder sb = new StringBuilder();
+            foreach (var line in content)
+            {
+                if (line.StartsWith("steam game port ="))
+                {
+                    sb.Append($"steam game port = {serverData.ServerPort}");
+                }
+                else if (line.StartsWith("steam query port ="))
+                {
+                    sb.Append($"steam query port = {serverData.ServerQueryPort}");
+                }
+                else if (line.StartsWith("server name = "))
+                {
+                    sb.Append($"server name = {serverData.ServerName}");
+                }
+                else if (line.StartsWith("display name ="))
+                {
+                    sb.Append($"display name = {serverData.ServerName}");
+                }
+                //else if (line.StartsWith("authentication token ="))
+                //{
+                //    sb.Append($"authentication token = {serverData.ServerGSLT}"); 
+                //} //
+                else
+                {
+                    sb.Append(line);
+                }
+            }
+
+            File.WriteAllText(configPath, sb.ToString());
         }
 
         // - Start server function, return its Process to WindowsGSM

--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -80,7 +80,10 @@ namespace WindowsGSM.Plugins
                 }
                 else if (line.StartsWith("authentication token =")) 
                 {
-                    sb.AppendLine($"authentication token = {serverData.ServerGSLT}"); 
+                    if (!string.IsNullOrWhiteSpace(serverData.ServerGSLT))
+                    {
+                        sb.AppendLine($"authentication token = {serverData.ServerGSLT}");
+                    }
                 }
                 else
                 {
@@ -183,4 +186,5 @@ namespace WindowsGSM.Plugins
 
     }
 }
+
 

--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -80,7 +80,7 @@ namespace WindowsGSM.Plugins
                 }
                 else if (line.StartsWith("authentication token =")) 
                 {
-                    sb.Append($"authentication token = {serverData.ServerGSLT}"); 
+                    sb.AppendLine($"authentication token = {serverData.ServerGSLT}"); 
                 }
                 else
                 {

--- a/ASKA.cs/ASKA.cs
+++ b/ASKA.cs/ASKA.cs
@@ -18,7 +18,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.ASKA", // WindowsGSM.XXXX
             author = "Gimpy",
             description = "WindowsGSM plugin for supporting ASKA Dedicated Server",
-            version = "1.2",
+            version = "1.3",
             url = "https://github.com/tadavispmd040507/WindowsGSM.ASKA", // Github repository link (Best practice)
             color = "#12ff12" // Color Hex
         };
@@ -183,3 +183,4 @@ namespace WindowsGSM.Plugins
 
     }
 }
+


### PR DESCRIPTION
- the GSLT replace line broke wgsm when no GSLT was set
- updated it to actually update lines, and not replace the old values
- use serverData.EmbedConsole to determine if embedConsole is even enabled, as we only should forward the console when enabled